### PR TITLE
feat: ActiveMQ Classic examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,12 +75,15 @@ testlogger {
  * Copy Test Libs for Examples
  **********************************************************************************************************************/
 task copyTestLibs(type: Copy) {
-    description = 'Copies RabbitMQ and ActiveMQ JMS client libs to build/test-libs for manual testing examples'
+    description = 'Copies RabbitMQ, ActiveMQ Artemis, and ActiveMQ Classic JMS client libs to build/test-libs for manual testing examples'
     from configurations.testRuntimeClasspath.filter {
         it.name.contains('rabbitmq-jms') ||
         it.name.contains('amqp-client') ||
         it.name.startsWith('artemis-') ||  // Get ALL artemis JARs (jakarta-client, commons, core-client, selector)
         it.name.startsWith('netty-') ||    // Get Netty for Artemis transport
+        it.name.startsWith('activemq-') || // Get ActiveMQ Classic client JARs
+        it.name.startsWith('hawtbuf-') ||  // ActiveMQ Classic dependency
+        it.name.startsWith('geronimo-') || // ActiveMQ Classic JMS spec dependency
         it.name.startsWith('commons-')     // Get Apache Commons libraries (beanutils, collections, logging)
     }
     into 'build/test-libs'
@@ -133,6 +136,9 @@ dependencies {
 
     // ActiveMQ Artemis Jakarta client for integration tests (Jakarta JMS 3.x)
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.43.0"
+
+    // ActiveMQ Classic client for integration tests and examples (classic ActiveMQ 5.x)
+    testImplementation "org.apache.activemq:activemq-client:5.19.1"
 }
 
 /**********************************************************************************************************************\

--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -58,6 +58,45 @@ In the Kestra UI, import the example flows from `src/examples/flows/activemq/`:
 2. Execute **jms_consume_activemq** to read messages
 3. Enable **jms_trigger_activemq** and send more messages to see it trigger automatically
 
+## Alternative: Quick Start with ActiveMQ Classic
+
+ActiveMQ Classic (5.x series) is the legacy version of ActiveMQ, different from the modern ActiveMQ Artemis. Use this if you're working with existing ActiveMQ Classic infrastructure.
+
+### 1. Build and Start Services
+
+```bash
+# Build plugin (if not done yet)
+./gradlew build -x test
+
+# Start services with ActiveMQ Classic
+docker-compose -f src/examples/docker/docker-compose-activemq-classic.yml up
+```
+
+This starts:
+- **ActiveMQ Classic** on ports 61616 (JMS) and 8161 (Web Console)
+- **Kestra** on port 8080
+
+### 2. Access UIs
+
+- **Kestra UI**: http://localhost:8080
+- **ActiveMQ Console**: http://localhost:8161/admin (admin/admin)
+
+### 3. Import Example Flows
+
+In the Kestra UI, import the example flows from `src/examples/flows/activemq-classic/`:
+
+- **jms_produce_activemq_classic.yaml** - Send a message to an ActiveMQ Classic queue
+- **jms_consume_activemq_classic.yaml** - Consume messages from a queue
+- **jms_trigger_activemq_classic.yaml** - Trigger a flow when messages arrive
+
+### 4. Run Examples
+
+1. Execute **jms_produce_activemq_classic** to send a test message
+2. Execute **jms_consume_activemq_classic** to read messages
+3. Enable **jms_trigger_activemq_classic** and send more messages to see it trigger automatically
+
+**Note:** The key difference from Artemis is the connection factory class: `org.apache.activemq.ActiveMQConnectionFactory` (Classic) vs `org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory` (Artemis) and the slightly different connection property names userName vs user.
+
 ## Alternative: Quick Start with RabbitMQ
 
 RabbitMQ is also supported as an alternative JMS provider.
@@ -171,27 +210,32 @@ docker-compose -f ../../docker-compose-ci.yml up -d
 
 ```
 src/examples/
-├── README.md                           # This file
+├── README.md                                # This file
 ├── docker/
-│   ├── docker-compose.yml             # Default: ActiveMQ Artemis quick-start
-│   ├── docker-compose-rabbitmq.yml    # Alternative: RabbitMQ setup
-│   └── docker-compose-sonicmq.yml     # SonicMQ/Aurea Messenger setup
+│   ├── docker-compose.yml                  # Default: ActiveMQ Artemis quick-start
+│   ├── docker-compose-activemq-classic.yml # Alternative: ActiveMQ Classic (5.x)
+│   ├── docker-compose-rabbitmq.yml         # Alternative: RabbitMQ setup
+│   └── docker-compose-sonicmq.yml          # SonicMQ/Aurea Messenger setup
 └── flows/
-    ├── activemq/                      # ActiveMQ Artemis examples (default)
+    ├── activemq/                           # ActiveMQ Artemis examples (default)
     │   ├── jms_produce_activemq.yaml
     │   ├── jms_consume_activemq.yaml
     │   └── jms_trigger_activemq.yaml
-    ├── rabbitmq/                      # RabbitMQ examples (alternative)
+    ├── activemq-classic/                   # ActiveMQ Classic (5.x) examples
+    │   ├── jms_produce_activemq_classic.yaml
+    │   ├── jms_consume_activemq_classic.yaml
+    │   └── jms_trigger_activemq_classic.yaml
+    ├── rabbitmq/                           # RabbitMQ examples (alternative)
     │   ├── jms_send.yaml
     │   ├── jms_consume.yaml
     │   └── jms_trigger.yaml
-    └── sonicmq/                       # SonicMQ/Aurea Messenger examples
-        ├── direct/                    # Direct connection examples
+    └── sonicmq/                            # SonicMQ/Aurea Messenger examples
+        ├── direct/                         # Direct connection examples
         │   ├── jms_send.yaml
         │   ├── jms_consume.yaml
         │   ├── jms_trigger.yaml
         │   └── jms_trigger_with_reply.yaml
-        └── jndi/                      # JNDI connection examples
+        └── jndi/                           # JNDI connection examples
             ├── jms_send_jndi.yaml
             ├── jms_consume_jndi.yaml
             └── jms_trigger_jndi.yaml
@@ -199,7 +243,8 @@ src/examples/
 
 ## Notes
 
-- **ActiveMQ Artemis** is recommended for quick testing and development (full JMS support)
+- **ActiveMQ Artemis** is recommended for quick testing and development (full JMS support, modern architecture)
+- **ActiveMQ Classic** (5.x series) is the legacy version, use if working with existing Classic infrastructure
 - **RabbitMQ** is supported but has limited JMS features (no message selectors)
 - **SonicMQ/Aurea Messenger** examples demonstrate advanced JMS features and JNDI lookup
 - All setups mount the plugin from `build/libs/` so you can rebuild and restart to test changes

--- a/src/examples/docker/docker-compose-activemq-classic.yml
+++ b/src/examples/docker/docker-compose-activemq-classic.yml
@@ -1,0 +1,52 @@
+version: "3.8"
+name: kestra-jms-activemq-classic
+
+# Docker Compose setup with ActiveMQ Classic (5.x)
+#
+# USAGE:
+# 1. Build the plugin (skips tests to avoid port conflicts):
+#    ./gradlew build -x test
+#
+# 2. Start the services:
+#    docker-compose -f src/examples/docker/docker-compose-activemq-classic.yml up
+#
+# 3. Access:
+#    - Kestra UI: http://localhost:8080
+#    - ActiveMQ Console: http://localhost:8161/admin (admin/admin)
+
+services:
+  activemq-classic:
+    image: apache/activemq-classic:latest
+    ports:
+      - "61616:61616"  # JMS/OpenWire port
+      - "8161:8161"    # Web console
+      - "1099:1099"   # jmx
+      - "1098:1098"   # rmi
+    environment:
+      ACTIVEMQ_USERNAME: admin
+      ACTIVEMQ_PASSWORD: admin
+      ACTIVEMQ_OPTS: -Djava.rmi.server.hostname=host.docker.internal -Dcom.sun.management.jmxremote.port=1099 -Dcom.sun.management.jmxremote.rmi.port=1099 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dactivemq.remoteurl=tcp://host.docker.internal:61616 -Dactivemq.transportConnectors.server.uri.tcp=tcp://0.0.0.0:61616
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8161/admin/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  kestra:
+    image: kestra/kestra:v1.0.3
+    entrypoint: /bin/sh -c "
+      cd /app/ && \
+      ./kestra server local"
+    ports:
+      - "8080:8080"      # Kestra UI
+      - "7999:7999"      # Debug port (optional)
+    volumes:
+      # Mount only the JMS plugin JAR (version-neutral name created by build)
+      - ../../../build/libs/plugin-jms-docker.jar:/app/plugins/plugin-jms.jar:ro
+      # Mount ActiveMQ Classic client libs (automatically copied during build)
+      - ../../../build/test-libs/:/app/plugins/jms-libs/:ro
+    depends_on:
+      activemq-classic:
+        condition: service_healthy
+    #environment:
+    #   - JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:7999

--- a/src/examples/flows/activemq-classic/jms_consume_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_consume_activemq_classic.yaml
@@ -1,0 +1,33 @@
+id: jms_consume_activemq_classic
+namespace: io.kestra.examples
+
+description: |
+  Consume messages from an ActiveMQ Classic queue using JMS.
+
+  ActiveMQ Classic is the legacy 5.x version of ActiveMQ, different from ActiveMQ Artemis.
+
+  Prerequisites:
+  - Build: ./gradlew build -x test
+  - Start: docker-compose -f src/examples/docker/docker-compose-activemq-classic.yml up
+  - Send messages first using jms_produce_activemq_classic.yaml
+
+tasks:
+  - id: consume_messages
+    type: io.kestra.plugin.jms.JMSConsumer
+    connectionFactoryConfig:
+      type: DIRECT
+      connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory
+      connectionProperties:
+        brokerURL: tcp://activemq-classic:61616
+        userName: admin
+        password: admin
+    destination:
+      destinationName: kestra.example.queue
+      destinationType: QUEUE
+    maxMessages: 10
+    maxWaitTimeout: 5000
+    serdeType: STRING
+
+  - id: log_result
+    type: io.kestra.plugin.core.log.Log
+    message: "Consumed {{ outputs.consume_messages.count }} message(s) from ActiveMQ Classic"

--- a/src/examples/flows/activemq-classic/jms_produce_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_produce_activemq_classic.yaml
@@ -1,0 +1,50 @@
+id: jms_produce_activemq_classic
+namespace: io.kestra.examples
+
+description: |
+  Send messages to an ActiveMQ Classic queue using JMS with different input formats.
+
+  ActiveMQ Classic is the legacy 5.x version of ActiveMQ, different from ActiveMQ Artemis.
+
+  Prerequisites:
+  - Build: ./gradlew build -x test
+  - Start: docker-compose -f src/examples/docker/docker-compose-activemq-classic.yml up
+
+tasks:
+  # Example 1: Plain string message (simple use case)
+  - id: send_plain_text
+    type: io.kestra.plugin.jms.JMSProducer
+    connectionFactoryConfig:
+      type: DIRECT
+      connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory
+      connectionProperties:
+        brokerURL: tcp://activemq-classic:61616
+        userName: admin
+        password: admin
+    destination:
+      destinationName: kestra.example.queue
+      destinationType: QUEUE
+    from: "Hello from Kestra JMS Plugin!"
+
+  # Example 2: Structured message with custom headers (advanced use case)
+  - id: send_with_headers
+    type: io.kestra.plugin.jms.JMSProducer
+    connectionFactoryConfig:
+      type: DIRECT
+      connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory
+      connectionProperties:
+        brokerURL: tcp://activemq-classic:61616
+        userName: admin
+        password: admin
+    destination:
+      destinationName: kestra.example.queue
+      destinationType: QUEUE
+    from:
+      data: "Message with custom headers"
+      headers:
+        customProperty: "value1"
+        priority: 5
+
+  - id: log_success
+    type: io.kestra.plugin.core.log.Log
+    message: "Messages sent successfully to ActiveMQ Classic queue"

--- a/src/examples/flows/activemq-classic/jms_trigger_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_trigger_activemq_classic.yaml
@@ -1,0 +1,38 @@
+id: jms_trigger_activemq_classic
+namespace: io.kestra.examples
+
+description: |
+  Trigger a flow when a message arrives on an ActiveMQ Classic queue.
+
+  ActiveMQ Classic is the legacy 5.x version of ActiveMQ, different from ActiveMQ Artemis.
+
+  Prerequisites:
+  - Build: ./gradlew build -x test
+  - Start: docker-compose -f src/examples/docker/docker-compose-activemq-classic.yml up
+  - Send messages using jms_produce_activemq_classic.yaml to trigger this flow
+
+tasks:
+  - id: process_message
+    type: io.kestra.plugin.core.log.Log
+    message: "Received message: {{ trigger.data }}"
+
+  - id: log_metadata
+    type: io.kestra.plugin.core.log.Log
+    message: |
+      Message ID: {{ trigger.messageId }}
+      Timestamp: {{ trigger.timestamp }}
+
+triggers:
+  - id: watch_queue
+    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    connectionFactoryConfig:
+      type: DIRECT
+      connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory
+      connectionProperties:
+        brokerURL: tcp://activemq-classic:61616
+        userName: admin
+        password: admin
+    destination:
+      destinationName: kestra.example.queue
+      destinationType: QUEUE
+    serdeType: STRING


### PR DESCRIPTION
Added examples for ActiveMQ Classic as many users still use that instead of Artemis.

### What changes are being made and why?
Just example docker and flows plus test dependency for the client jars.

---

### How the changes have been QAed?

Started the docker container that I added and ran the example flows.

---



---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
