### PR TITLE
refactor: rename tasks and use Property.ofValue

### DIFF
--- a/src/examples/flows/activemq-classic/jms_consume_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_consume_activemq_classic.yaml
@@ -13,7 +13,7 @@ description: |
 
 tasks:
   - id: consume_messages
-    type: io.kestra.plugin.jms.JMSConsumer
+    type: io.kestra.plugin.jms.Consume
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory

--- a/src/examples/flows/activemq-classic/jms_produce_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_produce_activemq_classic.yaml
@@ -13,7 +13,7 @@ description: |
 tasks:
   # Example 1: Plain string message (simple use case)
   - id: send_plain_text
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory
@@ -28,7 +28,7 @@ tasks:
 
   # Example 2: Structured message with custom headers (advanced use case)
   - id: send_with_headers
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory

--- a/src/examples/flows/activemq-classic/jms_trigger_activemq_classic.yaml
+++ b/src/examples/flows/activemq-classic/jms_trigger_activemq_classic.yaml
@@ -24,7 +24,7 @@ tasks:
 
 triggers:
   - id: watch_queue
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.ActiveMQConnectionFactory

--- a/src/examples/flows/activemq/jms_consume_activemq.yaml
+++ b/src/examples/flows/activemq/jms_consume_activemq.yaml
@@ -11,7 +11,7 @@ description: |
 
 tasks:
   - id: consume_messages
-    type: io.kestra.plugin.jms.JMSConsumer
+    type: io.kestra.plugin.jms.Consume
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory

--- a/src/examples/flows/activemq/jms_produce_activemq.yaml
+++ b/src/examples/flows/activemq/jms_produce_activemq.yaml
@@ -11,7 +11,7 @@ description: |
 tasks:
   # Example 1: Plain string message (simple use case)
   - id: send_plain_text
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
@@ -26,7 +26,7 @@ tasks:
 
   # Example 2: Structured message with custom headers (advanced use case)
   - id: send_with_headers
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory

--- a/src/examples/flows/activemq/jms_trigger_activemq.yaml
+++ b/src/examples/flows/activemq/jms_trigger_activemq.yaml
@@ -22,7 +22,7 @@ tasks:
 
 triggers:
   - id: watch_queue
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory

--- a/src/examples/flows/rabbitmq/jms_consume_rabbitmq.yaml
+++ b/src/examples/flows/rabbitmq/jms_consume_rabbitmq.yaml
@@ -11,7 +11,7 @@ description: |
 
 tasks:
   - id: consume_messages
-    type: io.kestra.plugin.jms.JMSConsumer
+    type: io.kestra.plugin.jms.Consume
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: com.rabbitmq.jms.admin.RMQConnectionFactory

--- a/src/examples/flows/rabbitmq/jms_produce_rabbitmq.yaml
+++ b/src/examples/flows/rabbitmq/jms_produce_rabbitmq.yaml
@@ -10,7 +10,7 @@ description: |
 
 tasks:
   - id: send_message
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: com.rabbitmq.jms.admin.RMQConnectionFactory

--- a/src/examples/flows/rabbitmq/jms_trigger_rabbitmq.yaml
+++ b/src/examples/flows/rabbitmq/jms_trigger_rabbitmq.yaml
@@ -22,7 +22,7 @@ tasks:
 
 triggers:
   - id: watch_queue
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: DIRECT
       connectionFactoryClass: com.rabbitmq.jms.admin.RMQConnectionFactory

--- a/src/examples/flows/sonicmq/direct/jms_consume_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/direct/jms_consume_sonicmq.yaml
@@ -4,7 +4,7 @@ namespace: at.conapi
 tasks:
 
   - id: jms-consume
-    type: io.kestra.plugin.jms.JMSConsumer
+    type: io.kestra.plugin.jms.Consume
     connectionFactoryConfig:
       type: DIRECT
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/direct/jms_produce_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/direct/jms_produce_sonicmq.yaml
@@ -4,7 +4,7 @@ namespace: at.conapi
 tasks:
 
   - id: jms-send
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/direct/jms_trigger_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/direct/jms_trigger_sonicmq.yaml
@@ -3,7 +3,7 @@ namespace: at.conapi
 
 triggers:
   - id: jms-trigger
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: DIRECT
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/direct/jms_trigger_with_reply_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/direct/jms_trigger_with_reply_sonicmq.yaml
@@ -3,7 +3,7 @@ namespace: at.conapi
 
 triggers:
   - id: jms-trigger
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: DIRECT
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/direct/jms_trigger_with_reply_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/direct/jms_trigger_with_reply_sonicmq.yaml
@@ -24,7 +24,7 @@ tasks:
 
 
   - id: jms-send
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: DIRECT
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/jndi/jms_consume_jndi_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/jndi/jms_consume_jndi_sonicmq.yaml
@@ -4,7 +4,7 @@ namespace: at.conapi
 tasks:
 
   - id: jms-consume
-    type: io.kestra.plugin.jms.JMSConsumer
+    type: io.kestra.plugin.jms.Consume
     connectionFactoryConfig:
       type: JNDI
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/jndi/jms_produce_jndi_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/jndi/jms_produce_jndi_sonicmq.yaml
@@ -4,7 +4,7 @@ namespace: at.conapi
 tasks:
 
   - id: jms-send
-    type: io.kestra.plugin.jms.JMSProducer
+    type: io.kestra.plugin.jms.Produce
     connectionFactoryConfig:
       type: JNDI
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/examples/flows/sonicmq/jndi/jms_trigger_jndi_sonicmq.yaml
+++ b/src/examples/flows/sonicmq/jndi/jms_trigger_jndi_sonicmq.yaml
@@ -3,7 +3,7 @@ namespace: at.conapi
 
 triggers:
   - id: jms-trigger
-    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+    type: io.kestra.plugin.jms.RealtimeTrigger
     connectionFactoryConfig:
       type: JNDI
       # Enable FilteredClassLoader for SonicMQ which bundles javax.jms classes in its JAR

--- a/src/main/java/io/kestra/plugin/jms/Consume.java
+++ b/src/main/java/io/kestra/plugin/jms/Consume.java
@@ -37,7 +37,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Getter
 @NoArgsConstructor
 @Schema(title = "Consume messages from a JMS queue or topic.", description = "It is recommended to set `maxWaitTimeout` or `maxMessages`.")
-@Plugin(examples = {
+@Plugin(
+    aliases = {"io.kestra.plugin.jms.JMSConsumer"},
+    examples = {
         @Example(
                 full = true,
                 title = "Consume 100 Messages from a JMS Queue",
@@ -47,7 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
                         tasks:
                           - id: consume_from_queue
-                            type: io.kestra.plugin.jms.JMSConsumer
+                            type: io.kestra.plugin.jms.Consume
                             connectionFactoryConfig:
                               type: DIRECT
                               providerJarPaths: kestra:///jms/activemq-client.jar
@@ -63,7 +65,7 @@ import java.util.concurrent.atomic.AtomicInteger;
         )
 })
 
-public class JMSConsumer extends AbstractJmsTask implements RunnableTask<JMSConsumer.Output> {
+public class Consume extends AbstractJmsTask implements RunnableTask<Consume.Output> {
 
     // NOTE: Using @PluginProperty instead of Property<JMSDestination> wrapper.
     // Nested configuration objects with @PluginProperty fields don't deserialize correctly
@@ -154,7 +156,7 @@ public class JMSConsumer extends AbstractJmsTask implements RunnableTask<JMSCons
         private final SerdeType rSerdeType;
         private final long rMaxWaitTimeout;
 
-        public ConsumeRunner(RunContext runContext, JMSConsumer task) throws Exception {
+        public ConsumeRunner(RunContext runContext, Consume task) throws Exception {
             this.rSerdeType = runContext.render(task.serdeType).as(SerdeType.class).orElseThrow();
             this.rMaxWaitTimeout = runContext.render(task.maxWaitTimeout).as(Long.class).orElseThrow();
 

--- a/src/main/java/io/kestra/plugin/jms/Produce.java
+++ b/src/main/java/io/kestra/plugin/jms/Produce.java
@@ -24,8 +24,6 @@ import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 
-import java.util.Map;
-
 /**
  * A Kestra task to produce messages to a JMS-compliant message broker.
  * This task connects to a broker and sends messages from a specified source.
@@ -36,7 +34,9 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor
 @Schema(title = "Produce messages to a JMS queue or topic.")
-@Plugin(examples = {
+@Plugin(
+    aliases = {"io.kestra.plugin.jms.JMSProducer"},
+    examples = {
         @Example(
                 full = true,
                 title = "Produce a List of Messages to a JMS Queue",
@@ -46,7 +46,7 @@ import java.util.Map;
 
                         tasks:
                           - id: produce_to_queue
-                            type: io.kestra.plugin.jms.JMSProducer
+                            type: io.kestra.plugin.jms.Produce
                             connectionFactoryConfig:
                               type: DIRECT
                               providerJarPaths: kestra:///jms/activemq-client.jar
@@ -66,7 +66,7 @@ import java.util.Map;
                         """
         )
 })
-public class JMSProducer extends AbstractJmsTask implements RunnableTask<JMSProducer.Output>, Data.From {
+public class Produce extends AbstractJmsTask implements RunnableTask<Produce.Output>, Data.From {
 
     // NOTE: Using @PluginProperty instead of Property<JMSDestination> wrapper.
     // Nested configuration objects with @PluginProperty fields don't deserialize correctly

--- a/src/main/java/io/kestra/plugin/jms/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/jms/RealtimeTrigger.java
@@ -5,8 +5,6 @@ import at.conapi.oss.jms.adapter.impl.ConnectionAdapter;
 import at.conapi.oss.jms.adapter.impl.ConnectionFactoryAdapter;
 import at.conapi.oss.jms.adapter.impl.ConsumerAdapter;
 import at.conapi.oss.jms.adapter.impl.SessionAdapter;
-import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
-import io.kestra.plugin.jms.serde.SerdeType;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
@@ -14,6 +12,8 @@ import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.triggers.*;
+import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
+import io.kestra.plugin.jms.serde.SerdeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -33,15 +33,16 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor
 @Schema(
-        title = "Trigger a flow execution on a JMS message.",
-        description = "This trigger listens to a JMS queue or topic and starts a new flow for each message."
+    title = "Trigger a flow execution on a JMS message.",
+    description = "This trigger listens to a JMS queue or topic and starts a new flow for each message."
 )
 @Plugin(
-        examples = {
-                @Example(
-                        title = "Start a flow for each message on a specific JMS queue.",
-                        full = true,
-                        code = """
+    aliases = {"io.kestra.plugin.jms.JMSRealtimeTrigger"},
+    examples = {
+        @Example(
+            title = "Start a flow for each message on a specific JMS queue.",
+            full = true,
+            code = """
                 id: jms-realtime-flow
                 namespace: at.conapi.dev
 
@@ -52,7 +53,7 @@ import java.util.Optional;
 
                 triggers:
                   - id: jms-trigger
-                    type: io.kestra.plugin.jms.JMSRealtimeTrigger
+                    type: io.kestra.plugin.jms.RealtimeTrigger
                     connectionFactoryConfig:
                       type: DIRECT
                       providerJarPaths: kestra:///jms/activemq-client.jar
@@ -61,10 +62,10 @@ import java.util.Optional;
                       name: "kestra.events"
                       destinationType: QUEUE
                 """
-                )
-        }
+        )
+    }
 )
-public class JMSRealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<JMSMessage> {
+public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerInterface, TriggerOutput<JMSMessage> {
 
     // NOTE: Using @PluginProperty instead of Property<ConnectionFactoryConfig> wrapper.
     // Polymorphic configuration objects with @JsonTypeInfo/@JsonSubTypes don't deserialize correctly
@@ -84,8 +85,8 @@ public class JMSRealtimeTrigger extends AbstractTrigger implements RealtimeTrigg
     private JMSDestination destination;
 
     @Schema(
-            title = "Message selector to only consume specific messages.",
-            description = "A JMS message selector expression to filter messages. Uses SQL-92 syntax (e.g., \"JMSPriority > 5 AND type = 'order'\")."
+        title = "Message selector to only consume specific messages.",
+        description = "A JMS message selector expression to filter messages. Uses SQL-92 syntax (e.g., \"JMSPriority > 5 AND type = 'order'\")."
     )
     private String messageSelector;
 
@@ -114,7 +115,7 @@ public class JMSRealtimeTrigger extends AbstractTrigger implements RealtimeTrigg
             } catch (Exception e) {
                 // If setup fails, we emit the error and the Flux terminates.
                 emitter.error(e);
-                if(jmsListener != null) {
+                if (jmsListener != null) {
                     jmsListener.close();
                 }
             }
@@ -138,13 +139,13 @@ public class JMSRealtimeTrigger extends AbstractTrigger implements RealtimeTrigg
         private ConnectionAdapter connection;
 
         public JmsListener(
-                io.kestra.core.runners.RunContext runContext,
-                ConnectionFactoryConfig connectionFactoryConfig,
-                JMSDestination destination,
-                String messageSelector,
-                SerdeType serdeType,
-                java.util.function.Consumer<JMSMessage> messageConsumer,
-                java.util.function.Consumer<Throwable> errorConsumer
+            io.kestra.core.runners.RunContext runContext,
+            ConnectionFactoryConfig connectionFactoryConfig,
+            JMSDestination destination,
+            String messageSelector,
+            SerdeType serdeType,
+            java.util.function.Consumer<JMSMessage> messageConsumer,
+            java.util.function.Consumer<Throwable> errorConsumer
         ) {
             this.runContext = runContext;
             this.connectionFactoryConfig = connectionFactoryConfig;

--- a/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
@@ -41,7 +41,7 @@ class ConsumeTest extends AbstractJMSTest {
             .id("consume-test")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -53,9 +53,9 @@ class ConsumeTest extends AbstractJMSTest {
                 .destinationName(TEST_QUEUE_NAME)
                 .destinationType(AbstractDestination.DestinationType.QUEUE)
                 .build())
-            .maxMessages(Property.of(1))
-            .maxWaitTimeout(Property.of(5000L))
-            .serdeType(Property.of(SerdeType.STRING))
+            .maxMessages(Property.ofValue(1))
+            .maxWaitTimeout(Property.ofValue(5000L))
+            .serdeType(Property.ofValue(SerdeType.STRING))
             .build();
 
         Consume.Output output = task.run(runContext);
@@ -85,7 +85,7 @@ class ConsumeTest extends AbstractJMSTest {
             .id("consume-test-multiple")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -97,9 +97,9 @@ class ConsumeTest extends AbstractJMSTest {
                 .destinationName(TEST_QUEUE_NAME)
                 .destinationType(AbstractDestination.DestinationType.QUEUE)
                 .build())
-            .maxMessages(Property.of(3))
-            .maxWaitTimeout(Property.of(5000L))
-            .serdeType(Property.of(SerdeType.STRING))
+            .maxMessages(Property.ofValue(3))
+            .maxWaitTimeout(Property.ofValue(5000L))
+            .serdeType(Property.ofValue(SerdeType.STRING))
             .build();
 
         Consume.Output output = task.run(runContext);
@@ -127,7 +127,7 @@ class ConsumeTest extends AbstractJMSTest {
             .id("consume-test-selector")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -140,9 +140,9 @@ class ConsumeTest extends AbstractJMSTest {
                 .destinationType(AbstractDestination.DestinationType.QUEUE)
                 .build())
             .messageSelector("priority = 10")
-            .maxMessages(Property.of(10))
-            .maxWaitTimeout(Property.of(5000L))
-            .serdeType(Property.of(SerdeType.STRING))
+            .maxMessages(Property.ofValue(10))
+            .maxWaitTimeout(Property.ofValue(5000L))
+            .serdeType(Property.ofValue(SerdeType.STRING))
             .build();
 
         Consume.Output output = task.run(runContext);
@@ -170,7 +170,7 @@ class ConsumeTest extends AbstractJMSTest {
             .id("consume-test-timeout")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -182,9 +182,9 @@ class ConsumeTest extends AbstractJMSTest {
                 .destinationName(TEST_QUEUE_NAME)
                 .destinationType(AbstractDestination.DestinationType.QUEUE)
                 .build())
-            .maxMessages(Property.of(10))
-            .maxWaitTimeout(Property.of(2000L)) // 2 seconds timeout
-            .serdeType(Property.of(SerdeType.STRING))
+            .maxMessages(Property.ofValue(10))
+            .maxWaitTimeout(Property.ofValue(2000L)) // 2 seconds timeout
+            .serdeType(Property.ofValue(SerdeType.STRING))
             .build();
 
         Consume.Output output = task.run(runContext);

--- a/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
@@ -1,13 +1,9 @@
 package io.kestra.plugin.jms;
 
 import at.conapi.oss.jms.adapter.AbstractDestination;
-import com.fasterxml.jackson.core.type.TypeReference;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
@@ -27,7 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
-class JMSConsumerTest extends AbstractJMSTest {
+class ConsumeTest extends AbstractJMSTest {
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -41,7 +37,7 @@ class JMSConsumerTest extends AbstractJMSTest {
         // Configure and run consumer
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSConsumer task = JMSConsumer.builder()
+        Consume task = Consume.builder()
             .id("consume-test")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -62,7 +58,7 @@ class JMSConsumerTest extends AbstractJMSTest {
             .serdeType(Property.of(SerdeType.STRING))
             .build();
 
-        JMSConsumer.Output output = task.run(runContext);
+        Consume.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getCount(), is(1));
@@ -85,7 +81,7 @@ class JMSConsumerTest extends AbstractJMSTest {
         // Configure and run consumer
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSConsumer task = JMSConsumer.builder()
+        Consume task = Consume.builder()
             .id("consume-test-multiple")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -106,7 +102,7 @@ class JMSConsumerTest extends AbstractJMSTest {
             .serdeType(Property.of(SerdeType.STRING))
             .build();
 
-        JMSConsumer.Output output = task.run(runContext);
+        Consume.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getCount(), is(3));
@@ -127,7 +123,7 @@ class JMSConsumerTest extends AbstractJMSTest {
         // Configure consumer with message selector
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSConsumer task = JMSConsumer.builder()
+        Consume task = Consume.builder()
             .id("consume-test-selector")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -149,7 +145,7 @@ class JMSConsumerTest extends AbstractJMSTest {
             .serdeType(Property.of(SerdeType.STRING))
             .build();
 
-        JMSConsumer.Output output = task.run(runContext);
+        Consume.Output output = task.run(runContext);
 
         // Should only consume 2 messages (those with priority = 10)
         assertThat(output.getCount(), is(2));
@@ -170,7 +166,7 @@ class JMSConsumerTest extends AbstractJMSTest {
         // Configure consumer with short timeout
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSConsumer task = JMSConsumer.builder()
+        Consume task = Consume.builder()
             .id("consume-test-timeout")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -191,7 +187,7 @@ class JMSConsumerTest extends AbstractJMSTest {
             .serdeType(Property.of(SerdeType.STRING))
             .build();
 
-        JMSConsumer.Output output = task.run(runContext);
+        Consume.Output output = task.run(runContext);
 
         // Should consume 0 messages due to timeout
         assertThat(output.getCount(), is(0));

--- a/src/test/java/io/kestra/plugin/jms/ProduceTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ProduceTest.java
@@ -47,7 +47,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -95,7 +95,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-multiple")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -149,7 +149,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-json")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -200,7 +200,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-headers")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -249,7 +249,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-plain-string")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -295,7 +295,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-json-string")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -350,7 +350,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-single-json")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,
@@ -416,7 +416,7 @@ class ProduceTest extends AbstractJMSTest {
             .id("produce-test-uri")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
-                    .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                    .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                     .connectionProperties(Map.of(
                         "brokerURL", ACTIVEMQ_URL,
                         "user", ACTIVEMQ_USER,

--- a/src/test/java/io/kestra/plugin/jms/ProduceTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ProduceTest.java
@@ -1,8 +1,7 @@
 package io.kestra.plugin.jms;
 
 import at.conapi.oss.jms.adapter.AbstractDestination;
-import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.flows.State;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -11,16 +10,11 @@ import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
 import io.kestra.plugin.jms.serde.SerdeType;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
+import jakarta.jms.*;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
-import jakarta.jms.Connection;
-import jakarta.jms.Message;
-import jakarta.jms.MessageConsumer;
-import jakarta.jms.Session;
-import jakarta.jms.TextMessage;
 import java.io.FileInputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -33,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
-class JMSProducerTest extends AbstractJMSTest {
+class ProduceTest extends AbstractJMSTest {
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -49,7 +43,7 @@ class JMSProducerTest extends AbstractJMSTest {
         // Configure and run producer
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -69,7 +63,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(1));
@@ -97,7 +91,7 @@ class JMSProducerTest extends AbstractJMSTest {
 
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-multiple")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -121,7 +115,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(3));
@@ -151,7 +145,7 @@ class JMSProducerTest extends AbstractJMSTest {
 
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-json")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -171,7 +165,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.JSON)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(1));
@@ -202,7 +196,7 @@ class JMSProducerTest extends AbstractJMSTest {
 
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-headers")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -225,7 +219,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(1));
@@ -251,7 +245,7 @@ class JMSProducerTest extends AbstractJMSTest {
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
         // Test with plain string (not JSON) - should be wrapped in JMSMessage
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-plain-string")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -271,7 +265,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(1));
@@ -297,7 +291,7 @@ class JMSProducerTest extends AbstractJMSTest {
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
         // Test with JSON array string (using Data.From pattern)
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-json-string")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -322,7 +316,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(2));
@@ -352,7 +346,7 @@ class JMSProducerTest extends AbstractJMSTest {
         RunContext runContext = runContextFactory.of(Map.of("testId", IdUtils.create()));
 
         // Test with single JSON object string (using Data.From pattern)
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-single-json")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -374,7 +368,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(1));
@@ -418,7 +412,7 @@ class JMSProducerTest extends AbstractJMSTest {
         ));
 
         // Test with Kestra URI (using Data.From pattern)
-        JMSProducer task = JMSProducer.builder()
+        Produce task = Produce.builder()
             .id("produce-test-uri")
             .connectionFactoryConfig(
                 ConnectionFactoryConfig.Direct.builder()
@@ -438,7 +432,7 @@ class JMSProducerTest extends AbstractJMSTest {
             .serdeType(SerdeType.STRING)
             .build();
 
-        JMSProducer.Output output = task.run(runContext);
+        Produce.Output output = task.run(runContext);
 
         // Verify output
         assertThat(output.getMessagesCount(), is(3));

--- a/src/test/java/io/kestra/plugin/jms/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/jms/RealtimeTriggerTest.java
@@ -1,15 +1,14 @@
 package io.kestra.plugin.jms;
 
 import at.conapi.oss.jms.adapter.AbstractDestination;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.flows.Flow;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
 import io.kestra.plugin.jms.serde.SerdeType;
-import io.kestra.core.junit.annotations.KestraTest;
-import org.junit.jupiter.api.Test;
-
 import jakarta.jms.*;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -17,7 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @KestraTest
-class JMSRealtimeTriggerTest extends AbstractJMSTest {
+class RealtimeTriggerTest extends AbstractJMSTest {
 
     @Test
     void triggerOnMessageArrival() throws Exception {
@@ -33,7 +32,7 @@ class JMSRealtimeTriggerTest extends AbstractJMSTest {
             .namespace("io.kestra.test")
             .revision(1)
             .triggers(java.util.List.of(
-                JMSRealtimeTrigger.builder()
+                RealtimeTrigger.builder()
                     .id(triggerId)
                     .connectionFactoryConfig(
                         ConnectionFactoryConfig.Direct.builder()
@@ -57,9 +56,9 @@ class JMSRealtimeTriggerTest extends AbstractJMSTest {
 
         // Verify trigger configuration
         assertThat(flow.getTriggers(), hasSize(1));
-        assertThat(flow.getTriggers().get(0), instanceOf(JMSRealtimeTrigger.class));
+        assertThat(flow.getTriggers().get(0), instanceOf(RealtimeTrigger.class));
 
-        JMSRealtimeTrigger trigger = (JMSRealtimeTrigger) flow.getTriggers().get(0);
+        RealtimeTrigger trigger = (RealtimeTrigger) flow.getTriggers().get(0);
         // Note: In tests, we access the Property directly without rendering
         // trigger.getDestination() returns Property<JMSDestination>
         // We just verify the trigger was configured correctly
@@ -79,7 +78,7 @@ class JMSRealtimeTriggerTest extends AbstractJMSTest {
             .namespace("io.kestra.test")
             .revision(1)
             .triggers(java.util.List.of(
-                JMSRealtimeTrigger.builder()
+                RealtimeTrigger.builder()
                     .id(triggerId)
                     .connectionFactoryConfig(
                         ConnectionFactoryConfig.Direct.builder()
@@ -104,9 +103,9 @@ class JMSRealtimeTriggerTest extends AbstractJMSTest {
 
         // Verify trigger configuration includes selector
         assertThat(flow.getTriggers(), hasSize(1));
-        assertThat(flow.getTriggers().get(0), instanceOf(JMSRealtimeTrigger.class));
+        assertThat(flow.getTriggers().get(0), instanceOf(RealtimeTrigger.class));
 
-        JMSRealtimeTrigger trigger = (JMSRealtimeTrigger) flow.getTriggers().get(0);
+        RealtimeTrigger trigger = (RealtimeTrigger) flow.getTriggers().get(0);
         assertThat(trigger.getMessageSelector(), is("urgent = TRUE"));
         assertThat(trigger.getDestination(), notNullValue());
     }

--- a/src/test/java/io/kestra/plugin/jms/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/jms/RealtimeTriggerTest.java
@@ -36,7 +36,7 @@ class RealtimeTriggerTest extends AbstractJMSTest {
                     .id(triggerId)
                     .connectionFactoryConfig(
                         ConnectionFactoryConfig.Direct.builder()
-                            .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                            .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                             .connectionProperties(Map.of(
                                 "brokerURL", ACTIVEMQ_URL,
                                 "user", ACTIVEMQ_USER,
@@ -48,7 +48,7 @@ class RealtimeTriggerTest extends AbstractJMSTest {
                         .destinationName(TEST_QUEUE_NAME)
                         .destinationType(AbstractDestination.DestinationType.QUEUE)
                         .build())
-                    .serdeType(Property.of(SerdeType.STRING))
+                    .serdeType(Property.ofValue(SerdeType.STRING))
                     .build()
             ))
             .tasks(java.util.List.of())
@@ -82,7 +82,7 @@ class RealtimeTriggerTest extends AbstractJMSTest {
                     .id(triggerId)
                     .connectionFactoryConfig(
                         ConnectionFactoryConfig.Direct.builder()
-                            .connectionFactoryClass(Property.of("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
+                            .connectionFactoryClass(Property.ofValue("org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory"))
                             .connectionProperties(Map.of(
                                 "brokerURL", ACTIVEMQ_URL,
                                 "user", ACTIVEMQ_USER,
@@ -95,7 +95,7 @@ class RealtimeTriggerTest extends AbstractJMSTest {
                         .destinationType(AbstractDestination.DestinationType.QUEUE)
                         .build())
                     .messageSelector("urgent = TRUE")
-                    .serdeType(Property.of(SerdeType.STRING))
+                    .serdeType(Property.ofValue(SerdeType.STRING))
                     .build()
             ))
             .tasks(java.util.List.of())


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
