### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/jms/AbstractJmsTask.java
+++ b/src/main/java/io/kestra/plugin/jms/AbstractJmsTask.java
@@ -25,7 +25,7 @@ public abstract class AbstractJmsTask extends Task {
     // Polymorphic configuration objects with @JsonTypeInfo/@JsonSubTypes don't deserialize correctly
     // when wrapped in Property<>. Jackson cannot resolve the type discriminator ('type' field)
     // during Property deserialization, causing "missing type id property 'type'" errors.
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Schema(
         title = "Connection factory configuration.",
         description = "Configuration for connecting to the JMS broker. Supports both direct connection factory instantiation and JNDI lookup."

--- a/src/main/java/io/kestra/plugin/jms/Consume.java
+++ b/src/main/java/io/kestra/plugin/jms/Consume.java
@@ -76,12 +76,12 @@ public class Consume extends AbstractJmsTask implements RunnableTask<Consume.Out
     // Nested configuration objects with @PluginProperty fields don't deserialize correctly
     // when wrapped in Property<>. Other Kestra messaging plugins (AMQP, Solace) avoid nested
     // config objects entirely, using flat Property<String> fields instead.
-    @PluginProperty
+    @PluginProperty(group = "main")
     @NotNull
     @Schema(title = "Destination to consume", description = "Rendered queue or topic name; destinationType selects QUEUE vs TOPIC")
     private JMSDestination destination;
 
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "processing")
     @Schema(
         title = "Message selector",
         description = "Optional JMS selector to filter messages server-side using SQL-92 syntax (e.g., \"JMSPriority > 5 AND type = 'order'\")."
@@ -94,14 +94,17 @@ public class Consume extends AbstractJmsTask implements RunnableTask<Consume.Out
         description = "STRING for text, JSON for JSON-formatted text, BYTES for binary data.",
         defaultValue = "STRING"
     )
+    @PluginProperty(group = "advanced")
     private Property<SerdeType> serdeType = Property.ofValue(SerdeType.STRING);
 
     @Builder.Default
     @Schema(title = "Maximum messages to consume", description = "Rendered upper bound on messages; default 1")
+    @PluginProperty(group = "advanced")
     private Property<Integer> maxMessages = Property.ofValue(1);
 
     @Builder.Default
     @Schema(title = "Maximum wait time (ms)", description = "Rendered timeout in milliseconds; default 0 waits indefinitely")
+    @PluginProperty(group = "execution")
     private Property<Long> maxWaitTimeout = Property.ofValue(0L);
 
     @Override

--- a/src/main/java/io/kestra/plugin/jms/JMSConnectionInterface.java
+++ b/src/main/java/io/kestra/plugin/jms/JMSConnectionInterface.java
@@ -11,15 +11,15 @@ public interface JMSConnectionInterface {
         title = "Connection Factory Configuration",
         description = "Defines how to obtain the JMS ConnectionFactory, either by direct class instantiation or via a JNDI lookup."
     )
-    @PluginProperty
+    @PluginProperty(group = "main")
     @NotNull
     ConnectionFactoryConfig getConnectionFactoryConfig();
 
     @Schema(title = "The username for authentication.")
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     String getUsername();
 
     @Schema(title = "The password for authentication.")
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     String getPassword();
 }

--- a/src/main/java/io/kestra/plugin/jms/JMSDestination.java
+++ b/src/main/java/io/kestra/plugin/jms/JMSDestination.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Builder
 public class JMSDestination {
     @Schema(title = "Destination name", description = "Rendered JMS queue or topic name")
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "main")
     @NotNull
     private String destinationName;
 

--- a/src/main/java/io/kestra/plugin/jms/JMSMessage.java
+++ b/src/main/java/io/kestra/plugin/jms/JMSMessage.java
@@ -16,6 +16,7 @@ import at.conapi.oss.jms.adapter.AbstractMessage;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
+import io.kestra.core.models.annotations.PluginProperty;
 
 /**
  * Represents a message consumed from or produced to a JMS broker.
@@ -25,42 +26,54 @@ import lombok.Getter;
 @Builder
 public final class JMSMessage implements Output {
     @Schema(title = "The message's content type.")
+    @PluginProperty(group = "advanced")
     private final String contentType;
 
     @Schema(title = "The message's content encoding.")
+    @PluginProperty(group = "processing")
     private final String contentEncoding;
 
     @Schema(title = "A map of message headers (JMS properties).")
+    @PluginProperty(group = "advanced")
     private final Map<String, Object> headers;
 
     @Schema(title = "The JMS delivery mode (1 for non-persistent, 2 for persistent).")
+    @PluginProperty(group = "advanced")
     private final Integer deliveryMode;
 
     @Schema(title = "The message priority level.")
+    @PluginProperty(group = "advanced")
     private final Integer priority;
 
     @Schema(title = "The unique JMS Message ID.")
+    @PluginProperty(group = "advanced")
     private final String messageId;
 
     @Schema(title = "The JMS Correlation ID.")
+    @PluginProperty(group = "advanced")
     private final String correlationId;
 
     @Schema(title = "The name of the destination to which a reply should be sent.")
+    @PluginProperty(group = "destination")
     private final String replyTo;
 
     @Schema(title = "The type of the replyTo destination (QUEUE or TOPIC).")
     private final AbstractDestination.DestinationType replyToType;
 
     @Schema(title = "The duration until the message expires.")
+    @PluginProperty(group = "advanced")
     private final Duration expiration;
 
     @Schema(title = "The timestamp when the message was sent.")
+    @PluginProperty(group = "advanced")
     private final Instant timestamp;
 
     @Schema(title = "The message type identifier.")
+    @PluginProperty(group = "advanced")
     private final String type;
 
     @Schema(title = "The deserialized message body.")
+    @PluginProperty(group = "advanced")
     private final Object data;
 
     /**

--- a/src/main/java/io/kestra/plugin/jms/Produce.java
+++ b/src/main/java/io/kestra/plugin/jms/Produce.java
@@ -78,24 +78,28 @@ public class Produce extends AbstractJmsTask implements RunnableTask<Produce.Out
     // Nested configuration objects with @PluginProperty fields don't deserialize correctly
     // when wrapped in Property<>. Other Kestra messaging plugins (AMQP, Solace) avoid nested
     // config objects entirely, using flat Property<String> fields instead.
-    @PluginProperty
+    @PluginProperty(group = "main")
     @NotNull
     @Schema(title = "Destination for messages", description = "Rendered queue or topic name; destinationType chooses QUEUE vs TOPIC")
     private JMSDestination destination;
 
     @Builder.Default
     @Schema(title = "JMS priority", description = "Rendered integer priority 0-9; default 4")
+    @PluginProperty(group = "advanced")
     private Property<Integer> priority = Property.ofValue(4);
 
     @Builder.Default
     @Schema(title = "JMS delivery mode", description = "Rendered delivery mode flag; default 2 (PERSISTENT)")
+    @PluginProperty(group = "advanced")
     private Property<Integer> deliveryMode = Property.ofValue(2);
 
     @Builder.Default
     @Schema(title = "Message time to live", description = "Rendered TTL in milliseconds; default 0 keeps the message indefinitely")
+    @PluginProperty(group = "destination")
     private Property<Long> timeToLive = Property.ofValue(0L);
 
     @NotNull
+    @PluginProperty(group = "main")
     private Object from;
 
     @Builder.Default
@@ -104,6 +108,7 @@ public class Produce extends AbstractJmsTask implements RunnableTask<Produce.Out
         description = "Determines how message bodies are serialized: STRING for text, JSON for JSON-formatted text, BYTES for binary data.",
         defaultValue = "STRING"
     )
+    @PluginProperty(group = "advanced")
     private SerdeType serdeType = SerdeType.STRING;
 
     /**

--- a/src/main/java/io/kestra/plugin/jms/RealtimeTrigger.java
+++ b/src/main/java/io/kestra/plugin/jms/RealtimeTrigger.java
@@ -73,7 +73,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     // Polymorphic configuration objects with @JsonTypeInfo/@JsonSubTypes don't deserialize correctly
     // when wrapped in Property<>. Jackson cannot resolve the type discriminator ('type' field)
     // during Property deserialization, causing "missing type id property 'type'" errors.
-    @PluginProperty
+    @PluginProperty(group = "main")
     @NotNull
     private ConnectionFactoryConfig connectionFactoryConfig;
 
@@ -81,7 +81,7 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
     // Nested configuration objects with @PluginProperty fields don't deserialize correctly
     // when wrapped in Property<>. Other Kestra messaging plugins (AMQP, Solace) avoid nested
     // config objects entirely, using flat Property<String> fields instead.
-    @PluginProperty
+    @PluginProperty(group = "main")
     @NotNull
     @Schema(title = "Destination to consume", description = "Rendered queue or topic name; destinationType selects QUEUE vs TOPIC")
     private JMSDestination destination;
@@ -90,10 +90,12 @@ public class RealtimeTrigger extends AbstractTrigger implements RealtimeTriggerI
         title = "Message selector",
         description = "Optional JMS selector to filter messages server-side using SQL-92 syntax (e.g., \"JMSPriority > 5 AND type = 'order'\")."
     )
+    @PluginProperty(group = "advanced")
     private String messageSelector;
 
     @Builder.Default
     @Schema(title = "Deserialization format", description = "STRING for text, JSON for JSON text, BYTES for binary payloads.", defaultValue = "STRING")
+    @PluginProperty(group = "processing")
     private Property<SerdeType> serdeType = Property.ofValue(SerdeType.STRING);
 
     @Override

--- a/src/main/java/io/kestra/plugin/jms/configuration/ConnectionFactoryConfig.java
+++ b/src/main/java/io/kestra/plugin/jms/configuration/ConnectionFactoryConfig.java
@@ -33,7 +33,7 @@ public abstract class ConnectionFactoryConfig {
         title = "Provider JAR paths",
         description = "One or more paths to the JMS provider JARs (e.g., `file:///app/plugins/jms-libs/client.jar`). If unset, all JARs under the plugins/jms-libs folder are added to the classpath."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) // Allow single string in YAML
     private List<String> providerJarPaths;
 
@@ -41,21 +41,21 @@ public abstract class ConnectionFactoryConfig {
         title = "Username for broker authentication",
         description = "Rendered username used when creating the connection. Omit for JNDI if the ConnectionFactory already embeds credentials."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     private String username;
 
     @Schema(
         title = "Password for broker authentication",
         description = "Rendered password used when creating the connection. Omit for JNDI if the ConnectionFactory already embeds credentials."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     private String password;
 
     @Schema(
         title = "Connection properties",
         description = "Additional POJO properties applied to the Direct or JNDI ConnectionFactory instance."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     private Map<String, String> connectionProperties;
 
     @Builder.Default
@@ -64,6 +64,7 @@ public abstract class ConnectionFactoryConfig {
         description = "Enable only for providers that ship JMS API classes (e.g., SonicMQ/Aurea) to avoid ClassCastException by loading JMS APIs from the parent classloader. Leave disabled for typical providers like RabbitMQ, ActiveMQ, Artemis.",
         defaultValue = "false"
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> useFilteredClassLoader = Property.ofValue(false);
 
     // This is a hack to make JavaDoc working as annotation processor didn't run before JavaDoc.
@@ -83,6 +84,7 @@ public abstract class ConnectionFactoryConfig {
             examples = { "org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory" }
         )
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> connectionFactoryClass;
 
         // This is a hack to make JavaDoc working as annotation processor didn't run before JavaDoc.
@@ -103,20 +105,25 @@ public abstract class ConnectionFactoryConfig {
             example = "org.wildfly.naming.client.WildFlyInitialContextFactory"
         )
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> jndiInitialContextFactory;
 
         @Schema(title = "JNDI provider URL", example = "remote+http://localhost:8080")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> jndiProviderUrl;
 
         @Schema(title = "JNDI principal", example = "Administrator")
+        @PluginProperty(group = "advanced")
         private Property<String> jndiPrincipal;
 
         @Schema(title = "JNDI credentials", example = "password")
+        @PluginProperty(group = "connection")
         private Property<String> jndiCredentials;
 
         @Schema(title = "JNDI ConnectionFactory name", example = "jms/RemoteConnectionFactory")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> jndiConnectionFactoryName;
 
         // This is a hack to make JavaDoc working as annotation processor didn't run before JavaDoc.


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712