### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.4.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ConsumeTest.java
@@ -1,8 +1,6 @@
 package io.kestra.plugin.jms;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
+import java.io.BufferedInputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -12,7 +10,7 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jms.configuration.ConnectionFactoryConfig;
 import io.kestra.plugin.jms.serde.SerdeType;
@@ -251,14 +249,8 @@ class ConsumeTest extends AbstractJMSTest {
      * Helper method to read consumed messages from Kestra storage.
      */
     private List<JMSMessage> readMessagesFromStorage(RunContext runContext, java.net.URI uri) throws Exception {
-        List<JMSMessage> messages = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(uri)))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                JMSMessage message = JacksonMapper.ofIon().readValue(line, JMSMessage.class);
-                messages.add(message);
-            }
+        try (var inputStream = new BufferedInputStream(runContext.storage().getFile(uri), FileSerde.BUFFER_SIZE)) {
+            return FileSerde.readAll(inputStream, JMSMessage.class).collectList().block();
         }
-        return messages;
     }
 }

--- a/src/test/java/io/kestra/plugin/jms/ProduceTest.java
+++ b/src/test/java/io/kestra/plugin/jms/ProduceTest.java
@@ -1,6 +1,8 @@
 package io.kestra.plugin.jms;
 
+import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -446,7 +448,9 @@ class ProduceTest extends AbstractJMSTest {
             JMSMessage.builder().data("Message 2 from URI").build(),
             JMSMessage.builder().data("Message 3 from URI").build()
         );
-        FileSerde.writeAll(Files.newBufferedWriter(tempFile), Flux.fromIterable(inputMessages)).block();
+        try (var outputStream = new BufferedOutputStream(new FileOutputStream(tempFile.toFile()), FileSerde.BUFFER_SIZE)) {
+            FileSerde.writeAll(outputStream, Flux.fromIterable(inputMessages)).block();
+        }
 
         // Upload to Kestra storage
         URI storageUri;


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.